### PR TITLE
Add fullscreen, change language to English (en), and separate toolbar

### DIFF
--- a/resources/assets/js/components/Editor.vue
+++ b/resources/assets/js/components/Editor.vue
@@ -24,6 +24,14 @@
             >
                 <span class="glyphicon glyphicon-download"></span>
             </button>
+            <button type="button"
+                    class="btn btn-default"
+                    title="Full Window/Fullscreen"
+                    @click="fullwin"
+                    v-show="openFile !== null"
+            >
+                <span class="glyphicon glyphicon-fullscreen"></span>
+            </button>
         </div>
     </div>
 </template>
@@ -47,6 +55,15 @@
             },
             save() {
                 this.putContents(this.editor.getValue());
+            },
+            fullwin() {
+            //I only know JavaScript, not this babel stuff, so here goes nothing (B>):
+            //Reconfigure this into your language
+                if (querySelector("div.col-editor").className = "fullscr") {
+                querySelector("div.col-editor").className = ""
+                } else {
+                querySelector("div.col-editor").className = "fullscr"
+                }
             },
             hide() {
                 this.setEditorVisibility(false);
@@ -90,11 +107,18 @@
 </script>
 
 <style>
+    div.col-editor.fullscr {
+        width: 100%;
+    }
+    div.col-editor.fullscr #hide {
+    /* This hides the "hide" button in the fullscreen mode. To show it again, press the Fullscreen button again. */
+        display: none;
+    }
     #editor {
         position: relative;
         width: 100%;
         z-index: 500;
-        height: 100vh;
+        height: calc(100vh - 54px);
         font-size: 15px;
         line-height: 1.6;
     }
@@ -107,6 +131,7 @@
         width: 100%;
         z-index: 600;
         padding: 10px;
+        background-color: white;
     }
 
     #hide {

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="de">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">


### PR DESCRIPTION
- Separating the toolbar would remove the interference of the toolbar with the editor.
- A fullscreen button in the toolbar would allow for more code to be displayed on the screen.
- Browsers such as Chrome won't insist on translating English to English when the page says it's English.

Some of these changes are part of #11.